### PR TITLE
feat : add stamp services

### DIFF
--- a/myapp/src/app.js
+++ b/myapp/src/app.js
@@ -7,6 +7,7 @@ const userRoutes = require("./routes/userRoutes");
 const facilityRoutes = require("./routes/facilityRoutes");
 const mapRoutes = require("./routes/mapRoutes");
 const reviewRoutes = require("./routes/reviewRoutes");
+const stampRoutes = require("./routes/stampRoutes");
 const errorMiddleware = require("./middleware/errorMiddleware");
 
 const app = express();
@@ -22,6 +23,7 @@ app.use("/api/users", userRoutes);
 app.use("/api/facilities", facilityRoutes);
 app.use("/api/maps", mapRoutes);
 app.use("/api/reviews/", reviewRoutes);
+app.use("/api/stamps", stampRoutes);
 
 // Error Handling Middleware
 app.use(errorMiddleware);

--- a/myapp/src/controllers/stampController.js
+++ b/myapp/src/controllers/stampController.js
@@ -1,0 +1,31 @@
+const stampService = require('../services/stampService');
+
+module.exports = {
+    /** get stampbooks by query - user_id, facility_id */
+    getStampBook: async (req,res,next) => {
+        try{
+            const result = await stampService.getStampBook(req.query.user, req.query.facility);
+            res.status(200).json(result);
+        }catch(err){
+            res.status(404).json({message: "Failed to retrieve stampbooks!"});
+        }
+    },
+    /** create stampbook with user_id, facility_id */
+    createStampBook: async (req,res,next) => {
+        try{
+            const result = await stampService.createStampBook(req.body);
+            res.status(201).json(result[0]);
+        }catch(err){
+            res.status(409).json({message: err.message});
+        }
+    },
+    /** perform a stamp transaction */
+    stampTransaction: async (req,res,next) => {
+        try{
+            const result = await stampService.stampTransaction(req.body);
+            res.status(200).json(result[0]);
+        }catch(err){
+            next(err);
+        }
+    }
+}

--- a/myapp/src/helper/helper.js
+++ b/myapp/src/helper/helper.js
@@ -3,6 +3,7 @@ const passwordPattern = new RegExp("^[a-zA-Z0-9._\-]+$");
 
 module.exports = {
     USER_TYPES: [0,1,2],
+    TRANSACTION_TYPES: [0,1],
     IMG_FILE_TYPES: ['png', 'jpg', 'jpeg', 'bmp', 'gif', 'webp', 'psd'],
     parseBoolean: (string) => {
         string === "true" ? true : string === "false" ? false : undefined;

--- a/myapp/src/routes/stampRoutes.js
+++ b/myapp/src/routes/stampRoutes.js
@@ -1,0 +1,39 @@
+const { Router } = require('express');
+const router = Router();
+const stampController = require('../controllers/stampController');
+const { body, param, query } = require('express-validator');
+const { validatorChecker } = require('../middleware/validator');
+const { TRANSACTION_TYPES } = require('../helper/helper');
+
+router
+    .get(       // GET : get stampbooks by query - userId, facilityId
+        '/',
+        [
+            query('user').optional().isInt({min: 1}),
+            query('facility').optional().isInt({min: 1}),
+            validatorChecker,
+        ],
+        stampController.getStampBook
+    ).post(     // POST : create stampbooks by userId, facilityId
+        '/create',
+        [
+            body('userId').exists().isInt({min: 1}),
+            body('facilityId').exists().isInt({min: 1}),
+            validatorChecker,
+        ],
+        stampController.createStampBook
+    ).post(     // POST : perform a stamp transaction
+        '/transaction',
+        [
+            body('buyerId').exists().isInt({min: 1}),
+            body('facilityId').exists().isInt({min: 1}),
+            body('sellerId').exists().isInt({min: 1}),
+            body('type').exists().isIn(TRANSACTION_TYPES),
+            body('amount').exists().isInt({min: 0}),
+            validatorChecker,
+        ],
+        stampController.stampTransaction
+    )
+;
+
+module.exports = router;

--- a/myapp/src/services/stampService.js
+++ b/myapp/src/services/stampService.js
@@ -1,0 +1,72 @@
+const db = require("../models/index");
+
+module.exports = {
+    /** get stampbooks by query - user_id, facility_id */
+    getStampBook: async (userId, facilityId) => {
+        values = [];
+        let baseQuery = `select * from stampbook where 1=1 `;
+        if(userId !== undefined){
+            values.push(userId);
+            baseQuery = baseQuery + `and user_id = $${values.length} `;
+        }
+        if(facilityId !== undefined){
+            values.push(facilityId);
+            baseQuery = baseQuery + `and facility_id = $${values.length}`;
+        }
+        const result = await db.query({
+            text: baseQuery,
+            values: values,
+        });
+        return result.rows;
+    },
+    /** create stampbook with user_id, facility_id */
+    createStampBook: async (body) => {
+        query = {
+            text: `insert into stampbook (user_id, facility_id) values ($1, $2) returning *`,
+            values: [body.userId, body.facilityId],
+        };
+        const result = await db.query(query);
+        return result.rows;
+    },
+    /**  
+     * perform a transaction 
+     * - args: buyer_id, facility_id, seller_id, type, amount
+     * 1. create row in "transaction" table
+     * 2. update row in "stampbook" corresponding to the buyer & facility
+     * 3. transaction type 0: -(amount), 1: +(amount) 
+     * 4. COMMIT or ROLLBACK
+     * */
+    stampTransaction: async (args) => {
+        try{
+            const amountDiff = (!!args.type ? 1 : -1) * args.amount;
+            await db.query('BEGIN');
+            let result = await db.query({
+                text: `insert into transaction (buyer_id, facility_id, seller_id, type, amount)
+                    values ($1, $2, $3, $4, $5)
+                    returning *`,
+                values: [
+                    args.buyerId, 
+                    args.facilityId,
+                    args.sellerId,
+                    args.type,
+                    args.amount,
+                ],
+            });
+            result = await db.query({
+                text: `update stampbook set cnt = cnt + $1
+                    where user_id = $2 and facility_id = $3
+                    returning *`,
+                values: [
+                    amountDiff,
+                    args.buyerId,
+                    args.facilityId,
+                ],
+            });
+            await db.query('COMMIT');
+            return result.rows;
+        }catch(err){
+            await db.query('ROLLBACK');
+            throw new Error(err);
+        }
+    },
+}


### PR DESCRIPTION
## What was added
- added stamp services stampRoutes, stampController, stampService
- added stampbook operations
    1. get stampbook by query - userId, facilityId
    2. create stampbook by userId, facilityId
- added transaction operation which does:
    1. add transaction record to "transaction" table
    2. update corresponding "stampbook"."cnt" value which is the number of current stamps
    3. transaction is either type 0: redeem or 1: gain stamps

## Related Issues
- link related issues here
- [REPO_NAME #issueNum](issue_address)

## Future Works
- What else should be done ?

## Checklist
- [x] I have performed unit tests
- [x] I have added necessary docs
- [x] I have checked for potential bugs & issues