### PR TITLE
Feature/user_permissions : Check user types for all API methods

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build:
       dockerfile: ./Dockerfile
       target: dev
+    image: fork_dev
+    pull_policy: build
     restart: unless-stopped
     ports:
       - "80:3000"
@@ -21,6 +23,8 @@ services:
     build:
       dockerfile: ./Dockerfile
       target: test
+    image: fork_test
+    pull_policy: build
     restart: unless-stopped
     ports:
       - "80:3000"
@@ -35,6 +39,8 @@ services:
     build:
       dockerfile: ./Dockerfile
       target: prod
+    image: fork_prod
+    pull_policy: build
     restart: unless-stopped
     ports:
       - "80:3000"

--- a/myapp/src/helper/helper.js
+++ b/myapp/src/helper/helper.js
@@ -9,9 +9,9 @@ module.exports = {
     REPORT_STATUS: [0,1],
     IMG_FILE_TYPES: ['png', 'jpg', 'jpeg', 'bmp', 'gif', 'webp', 'psd'],
     /** user type checks */
-    isAdmin: (user) => user.user_type === 0,
-    isKAISTUser: (user) => user.user_type === 1,
-    isFacilityUser: (user) => user.user_type === 2,
+    isAdmin: (headers) => headers.userType === 0,
+    isKAISTUser: (headers) => headers.userType === 1,
+    isFacilityUser: (headers) => headers.userType === 2,
     /** general helpers */
     parseBoolean: (string) => {
         return string === "true" ? true : string === "false" ? false : undefined;

--- a/myapp/src/middleware/authMiddleware.js
+++ b/myapp/src/middleware/authMiddleware.js
@@ -1,0 +1,20 @@
+const express = require('express');
+
+module.exports = {
+    /** check a requesting user's type which is in headers
+     * allow access to the method if user is one of 'allowedTypes'
+    */
+    checkPermission: (allowedTypes) => {
+        return (req,res,next) => {
+            const allowed = allowedTypes.includes(Number(req.header('userType')));
+            // const allowed = allowedTypes.includes(req.header('userType'));
+            if(!allowed){
+                return res.status(403).json({
+                    status: "fail",
+                    message: "User does not have permission to access this method",
+                })
+            }
+            next();
+        }
+    }
+}

--- a/myapp/src/routes/adminRoutes.js
+++ b/myapp/src/routes/adminRoutes.js
@@ -4,10 +4,12 @@ const adminController = require('../controllers/adminController');
 const { body, param, query } = require('express-validator');
 const { validatorChecker } = require('../middleware/validator');
 const { REPORT_TYPES, REPORT_STATUS } = require('../helper/helper');
+const { checkPermission } = require('../middleware/authMiddleware');
 
 router
     .get(       // GET : get report by id
         '/reports/:id',
+        checkPermission([0]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min: 1}),
             validatorChecker,
@@ -15,6 +17,7 @@ router
         adminController.getReport
     ).get(      // GET : get report by query - author_id, type, status
         '/reports',
+        checkPermission([0]),
         [
             query('user', `optional query field 'user' must be a positive integer`).optional().isInt({min: 1}),
             query('type', `optional query field 'type' must be one of ${REPORT_TYPES}`).optional().isIn(REPORT_TYPES),
@@ -24,6 +27,7 @@ router
         adminController.getReportByQuery
     ).post(     // POST : create a report
         '/reports/upload',
+        checkPermission([0,1,2]),
         [
             body('authorId', `body field 'authorId' must be a positive integer`).exists().isInt({min: 1}),
             body('type', `body field 'type' must be one of ${REPORT_TYPES}`).exists().isIn(REPORT_TYPES),
@@ -34,6 +38,7 @@ router
         adminController.createReport
     ).delete(   // DELETE : delete a report
         '/reports/delete/:id',
+        checkPermission([0]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min: 1}),
             validatorChecker,
@@ -41,6 +46,7 @@ router
         adminController.deleteReport
     ).post(     // POST : handle report and perform follow-up action
         '/reports/handle/:id',
+        checkPermission([0]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min: 1}),
             body('adminId', `body field 'adminId' must be a positive integer`).exists().isInt({min: 1}),

--- a/myapp/src/routes/authRoutes.js
+++ b/myapp/src/routes/authRoutes.js
@@ -3,10 +3,12 @@ const router = Router();
 const authController = require("../controllers/authController");
 const { body, param, query } = require("express-validator");
 const { validatorChecker } = require("../middleware/validator");
+const { checkPermission } = require("../middleware/authMiddleware");
 
 router
     .post(
         '/login',
+        checkPermission([-1]),  // only guests can login
         [
             body('userId').exists().notEmpty().isLength({max: 20}),
             body('password').exists().notEmpty().isLength({min: 6, max: 20}),

--- a/myapp/src/routes/facilityRoutes.js
+++ b/myapp/src/routes/facilityRoutes.js
@@ -1,8 +1,9 @@
 const { Router } = require("express");
 const facilityController = require("../controllers/facilityController");
-const { body, param } = require("express-validator");
+const { body, param, check } = require("express-validator");
 const { validatorChecker } = require("../middleware/validator");
 const { s3Uploader } = require("../helper/s3Engine");
+const { checkPermission } = require("../middleware/authMiddleware")
 
 const router = Router();
 
@@ -23,6 +24,7 @@ router.get(
 // to be commented later
 router.post(
   "/", // POST: create a new facility
+  checkPermission([0]),
   [
     body("name").notEmpty().withMessage("Name is required"),
     body("businessId").notEmpty().withMessage("Business ID is required"),
@@ -62,6 +64,7 @@ router.post(
 
 router.put(
   "/:id", // PUT : update a facility
+  checkPermission([0,2]),
   [
     param("id").isNumeric().withMessage("Valid ID is required"),
     body("name").notEmpty().withMessage("Name is required"),
@@ -76,6 +79,7 @@ router.put(
 
 router.delete(
   "/:id", // DELETE : delete a facility
+  checkPermission([0]),
   [
     param("id").isNumeric().withMessage("Valid ID is required"),
     validatorChecker,
@@ -95,6 +99,7 @@ router.get(
 
 router.post(
   "/:facilityId/address", // POST : add or update address for a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -116,6 +121,7 @@ router.post(
 
 router.delete(
   "/:facilityId/address", // DELETE : delete address for a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -137,6 +143,7 @@ router.get(
 );
 router.post(
   "/:facilityId/opening-hours", // POST : add opening hours for a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -160,6 +167,7 @@ router.post(
 );
 router.delete(
   "/:facilityId/opening-hours", // DELETE : delete opening hours for a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -192,6 +200,7 @@ router.get(
 );
 router.post(
   "/:facilityId/menu", // POST : create menu for a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -208,6 +217,7 @@ router.post(
 
 router.put(
   "/:facilityId/menu/:menuId", // PUT: update menu item with menuId
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -223,6 +233,7 @@ router.put(
 );
 router.delete(
   "/:facilityId/menu/:menuId", // DELETE: delete menu item of specified menuId
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -258,6 +269,7 @@ router.get(
 
 router.post(
   "/:facilityId/post", // POST : create a new post for a facility
+  checkPermission([0,2]),
   s3Uploader.single('image'),
   [
     param("facilityId")
@@ -275,6 +287,7 @@ router.post(
 
 router.put(
   "/:facilityId/post/:postId", // PUT : update a post for a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -289,6 +302,7 @@ router.put(
 
 router.delete(
   "/:facilityId/post/:postId", // DELETE : delete a post for a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -312,6 +326,7 @@ router.get(
 
 router.post(
   "/:facilityId/stamp-ruleset", // POST: create stamp-ruleset
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -333,6 +348,7 @@ router.post(
 
 router.put(
   "/:facilityId/stamp-ruleset", // PUT: update existing stamp-ruleset
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -347,6 +363,7 @@ router.put(
 
 router.post(
   "/:facilityId/stamp-rewards", // POST: add stamp-reward
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -360,6 +377,7 @@ router.post(
 
 router.put(
   "/:facilityId/stamp-rewards/:rewardId", // PUT: update existing stamp-reward
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -374,6 +392,7 @@ router.put(
 
 router.delete(
   "/:facilityId/stamp-rewards/:rewardId", // DELETE : delete stamp-reward with specified rewardId
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -397,6 +416,7 @@ router.get(
 
 router.post(
   "/:facilityId/preferences", // POST : add a preference to a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -411,6 +431,7 @@ router.post(
 
 router.delete(
   "/:facilityId/preferences/:preferenceId", // DELETE : remove a preference from a facility
+  checkPermission([0,2]),
   [
     param("facilityId")
       .isNumeric()
@@ -427,6 +448,7 @@ router.delete(
 router
   .post(      // POST : upload facility profile image
     '/:id/profile/image',
+    checkPermission([0,2]),
     s3Uploader.single('image'),
     [
         param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
@@ -435,6 +457,7 @@ router
     facilityController.uploadFacilityProfileImage
   ).delete(   // DELETE : delete facility profile image
     '/:id/profile/image',
+    checkPermission([0,2]),
     [
       param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
       validatorChecker,
@@ -442,6 +465,7 @@ router
     facilityController.deleteFacilityProfileImage
   ).post(     // POST : upload stamp logo image
     '/:id/stamp-ruleset/logo',
+    checkPermission([0,2]),
     s3Uploader.single('image'),
     [
       param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
@@ -450,6 +474,7 @@ router
     facilityController.uploadStampLogoImage
   ).delete(   // DELETE : delete stamp logo image
     '/:id/stamp-ruleset/logo',
+    checkPermission([0,2]),
     [
       param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
       validatorChecker,
@@ -457,6 +482,7 @@ router
     facilityController.deleteStampLogoImage
   ).post(     // POST : upload menu image
     '/:facilityId/menu/:menuId/image',
+    checkPermission([0,2]),
     s3Uploader.single('image'),
     [
       param('facilityId', `route param 'facilityId' must be a positive integer`).exists().isInt({min:1}),
@@ -466,6 +492,7 @@ router
     facilityController.uploadMenuImage
   ).delete(   // DELETE : delete menu image
     '/:facilityId/menu/:menuId/image',
+    checkPermission([0,2]),
     [
       param('facilityId', `route param 'facilityId' must be a positive integer`).exists().isInt({min:1}),
       param('menuId', `route param 'menuId' must be a positive integer`).exists().isInt({min:1}),

--- a/myapp/src/routes/reviewRoutes.js
+++ b/myapp/src/routes/reviewRoutes.js
@@ -5,11 +5,12 @@ const { body, param, query } = require('express-validator');
 const { validatorChecker } = require('../middleware/validator');
 const { s3Uploader } = require('../helper/s3Engine');
 const { IMG_FILE_TYPES, validateJSONArray, validateHashtagArray, validateIntArray } = require('../helper/helper');
+const { checkPermission } = require('../middleware/authMiddleware');
 
 
 /** Router for "/api/reviews" */
 router
-    .get(       // GET : get review by review id
+    .get(           // GET : get review by review id
         '/:id',
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min: 1}),
@@ -17,7 +18,7 @@ router
         ],
         reviewController.getReview
     )
-    .get(       // GET : get review by query
+    .get(           // GET : get review by query
         '/',
         [
             query('facility', `optional query field 'facility' must be a positive integer`).optional().isInt({min: 1}),
@@ -31,8 +32,9 @@ router
             validatorChecker,
         ],
         reviewController.getReviewByQuery
-    ).post(     // POST : create review w/ image attachment (up to 1 file)
+    ).post(         // POST : create review w/ image attachment (up to 1 file)
         '/upload',
+        checkPermission([0,1]),
         s3Uploader.single('image'),
         [
             body('authorId', `body field 'authorId' must be a positive integer`).exists().isInt({min: 1}),
@@ -43,8 +45,9 @@ router
             validatorChecker,
         ],
         reviewController.createReview
-    ).post(      // POST : edit review contents - content, hashtags
+    ).post(         // POST : edit review contents - content, hashtags
         '/:id',
+        checkPermission([0,1]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min: 1}),
             body('content', `body field 'content' must be string`).exists().isString(),
@@ -53,8 +56,9 @@ router
             validatorChecker,
         ],
         reviewController.updateReview
-    ).delete(
+    ).delete(       // DELETE : delete a review
         '/:id',
+        checkPermission([0,1]),
         [
             param('id', `route param 'id' must be a postive integer`).exists().isInt({min: 1}),
             validatorChecker,

--- a/myapp/src/routes/stampRoutes.js
+++ b/myapp/src/routes/stampRoutes.js
@@ -4,10 +4,12 @@ const stampController = require('../controllers/stampController');
 const { body, param, query } = require('express-validator');
 const { validatorChecker } = require('../middleware/validator');
 const { TRANSACTION_TYPES } = require('../helper/helper');
+const { checkPermission } = require('../middleware/authMiddleware');
 
 router
     .get(       // GET : get stampbooks by query - userId, facilityId
         '/',
+        checkPermission([0,1,2]),
         [
             query('user', `optional query field 'user' must be a positive integer`).optional().isInt({min: 1}),
             query('facility', `optional query field 'facility' must be a positive integer`).optional().isInt({min: 1}),
@@ -16,6 +18,7 @@ router
         stampController.getStampBook
     ).post(     // POST : create stampbooks by userId, facilityId
         '/create',
+        checkPermission([0,1,2]),
         [
             body('userId', `body field 'userId' must be a positive integer`).exists().isInt({min: 1}),
             body('facilityId', `body field 'facilityId' must be a positive integer`).exists().isInt({min: 1}),
@@ -24,6 +27,7 @@ router
         stampController.createStampBook
     ).post(     // POST : perform a stamp transaction
         '/transaction',
+        checkPermission([0,2]),     // Facility user (seller) is the initiator of the transaction
         [
             body('buyerId', `body field 'buyerId' must be a positive integer`).exists().isInt({min: 1}),
             body('facilityId', `body field 'facilityId' must be a positive integer`).exists().isInt({min: 1}),

--- a/myapp/src/routes/userRoutes.js
+++ b/myapp/src/routes/userRoutes.js
@@ -5,6 +5,7 @@ const { body, param, query } = require('express-validator');
 const { validatorChecker } = require('../middleware/validator');
 const { USER_TYPES, validateUserId, validatePassword } = require("../helper/helper");
 const { s3Uploader } = require('../helper/s3Engine');
+const { checkPermission } = require('../middleware/authMiddleware');
 
 
 /** Router for "/api/users" */
@@ -17,7 +18,7 @@ router
             validatorChecker,
         ],
         userController.getUsers
-    ).get(      // GET : get user by account_id
+    ).get(      // GET : get user by id
         '/:id',
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
@@ -26,6 +27,7 @@ router
         userController.getUserById
     ).post(     // POST : create new user
         '/create',
+        checkPermission([-1,0]),    // guest -> registration
         [
             body('userId', `body field 'userId' violates account id constraints`)
                 .exists().isString().isLength({min: 6, max: 20}).custom(validateUserId),
@@ -38,6 +40,7 @@ router
         userController.createUser
     ).put(      // PUT : update user - profile
         '/profile/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             body('password', `body field 'password' violates account password constraints`)
@@ -48,6 +51,7 @@ router
         userController.updateUserProfile
     ).delete(   // DELETE : delete a user
         '/delete/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             validatorChecker,
@@ -55,6 +59,7 @@ router
         userController.deleteUser
     ).get(      // GET : get user preferences
         '/preference/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             validatorChecker,
@@ -62,6 +67,7 @@ router
         userController.getUserPreference
     ).put(      // PUT : add a user preference
         '/preference/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             body('preferenceId', `body field 'preferenceId' must be a positive integer`).exists().isInt({min: 1}),
@@ -70,6 +76,7 @@ router
         userController.addUserPreference
     ).delete(   // DELETE : delete a user preference
         '/preference/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             body('preferenceId', `body field 'preferenceId' must be a positive integer`).exists().isInt({min: 1}),
@@ -78,6 +85,7 @@ router
         userController.deleteUserPreference
     ).get(      // GET : get favorites of a user
         '/favorite/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             validatorChecker,
@@ -85,6 +93,7 @@ router
         userController.getUserFavorite
     ).get(      // GET : check if a facility is user's favorite
         '/favorite/:user/has/:facility',
+        checkPermission([0,1,2]),
         [
             param('user', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             param('facility', `route param 'facility' must be a positive integer`).exists().isInt({min: 1}),
@@ -93,6 +102,7 @@ router
         userController.isUserFavorite
     ).put(      // PUT : add a user favorite, if not already added
         '/favorite/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             body('facilityId', `body field 'facilityId' must be a positive integer`).exists().isInt({min: 1}),
@@ -101,6 +111,7 @@ router
         userController.addUserFavorite
     ).delete(   // DELETE : delete a user favorite
         '/favorite/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             body('facilityId', `body field 'facilityId' must be a positive integer`).exists().isInt({min: 1}),
@@ -109,6 +120,7 @@ router
         userController.deleteUserFavorite
     ).post(      // POST : upload / update a user profile image
         '/profile/image/:id',
+        checkPermission([0,1,2]),
         s3Uploader.single('image'),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
@@ -117,6 +129,7 @@ router
         userController.uploadUserProfileImage
     ).delete(      // DELETE : delete a user profile image
         '/profile/image/:id',
+        checkPermission([0,1,2]),
         [
             param('id', `route param 'id' must be a positive integer`).exists().isInt({min:1}),
             validatorChecker,


### PR DESCRIPTION
## What was added
- added middleware to check if a requesting user's type is in certain types
    - authorization will set the header 'userType'
    - middleware will use the header for checking
- for methods that should restrict access for certain user types, add middleware for type checking

## Related Issues
- link related issues here
- [REPO_NAME #issueNum](issue_address)

## Future Works
- Merge & test with auth branch
- Add typechecks for all new methods

## Checklist
- [x] I have performed unit tests
- [ ] I have added necessary docs
- [x] I have checked for potential bugs & issues