### PR TITLE
Feature/trending : add GET methods for leaderboard - trending & newest facilities

### DIFF
--- a/myapp/src/controllers/facilityController.js
+++ b/myapp/src/controllers/facilityController.js
@@ -528,5 +528,30 @@ module.exports = {
       next(err);
     }
   },
+  /** get trending facilities */
+  getTrendingFacilities: async (req,res,next) => {
+    try{
+      const result = await facilityService.getTrendingFacilities(req.query);
+      res.status(200).json({
+        status: "success",
+        data: result,
+      });
+    }catch(err){
+      next(err);
+    }
+  },
+  /** get newest facilities */
+  getNewestFacilities: async (req,res,next) => {
+    try{
+      const limit = req.query.limit;
+      const result = await facilityService.getNewestFacilities(limit);
+      res.status(200).json({
+        status: "success",
+        data: result,
+      });
+    }catch(err){
+      next(err);
+    }
+  }
 
 };

--- a/myapp/src/routes/facilityRoutes.js
+++ b/myapp/src/routes/facilityRoutes.js
@@ -1,9 +1,10 @@
 const { Router } = require("express");
 const facilityController = require("../controllers/facilityController");
-const { body, param, check } = require("express-validator");
+const { body, param, query } = require("express-validator");
 const { validatorChecker } = require("../middleware/validator");
 const { s3Uploader } = require("../helper/s3Engine");
-const { checkPermission } = require("../middleware/authMiddleware")
+const { checkPermission } = require("../middleware/authMiddleware");
+const { validateIntArray } = require("../helper/helper");
 
 const router = Router();
 
@@ -500,8 +501,31 @@ router
     ],
     facilityController.deleteMenuImage
   )
+;
 
-
+/** leaderboard methods */
+router
+  .get(
+    '/leaderboard/trending',
+    [
+      query('limit', `query field 'limit' must be a positive integer`).exists().isInt({min: 1}),
+      query('preferences', `optional query field 'preferences' must be an integer array`)
+        .optional()
+        .isString()
+        .customSanitizer((e) => e.split(',').map((e) => Number(e)))
+        .custom(validateIntArray),
+      validatorChecker,
+    ],
+    facilityController.getTrendingFacilities
+  ).get(
+    '/leaderboard/newest',
+    [
+      query('limit', `query field 'limit' must be a positive integer`).exists().isInt({min: 1}),
+      validatorChecker,
+    ],
+    facilityController.getNewestFacilities
+  )
+;
 
 
 module.exports = router;

--- a/myapp/src/services/facilityService.js
+++ b/myapp/src/services/facilityService.js
@@ -903,6 +903,35 @@ class FacilityService {
     return result;
   }
 
+  /** get list of trending facilities 
+   * - (args) limit : limit result to top-K
+   * - (args) preferences : filter by list of preferences
+  */
+  async getTrendingFacilities (args) {
+    let values = [];
+    let baseQuery = `select fp.* from facility_pin fp where fp.avg_score is not null `;
+    if(args.preferences && args.preferences.length !== 0){
+      values.push(args.preferences);
+      baseQuery = baseQuery + `and fp.preference_ids && $${values.length} `;
+    }
+    const { rows } = await db.query({
+      text: baseQuery + `order by fp.avg_score desc limit ${args.limit} `,
+      values: values,
+    });
+    return rows;
+  }
+
+  /** get list of newest facilities
+   * - limit : limit result to top-K
+   */
+  async getNewestFacilities (limit) {
+    const { rows } = await db.query({
+      text: `select fp.* from facility_pin fp join facility f on fp.id = f.id order by f.created_at desc limit $1`,
+      values: [limit],
+    });
+    return rows;
+  }
+
 }
 
 module.exports = new FacilityService();


### PR DESCRIPTION
## What was added
- add getTrendingFacilities method `GET /api/facilities/leaderboard/trending`
    - get facilities that have at least 1 review, ordered by avg-score
    - query parameter 'limit' -> get top-K results
    - query parameter 'preferences' -> filter by preferences
- add getNewestFacilities method `GET /api/facilities/leaderboard/newest`
    - get facilities ordered by 'created_at' time
    - query parameter 'limit' -> get top-K results
    
### DOCS
https://cwwojin.github.io/FORK_backend/pages/facility.html#get--get-list-of-trending-facilities

## Related Issues
- link related issues here
- [REPO_NAME #issueNum](issue_address)

## Future Works
- What else should be done ?

## Checklist
- [x] I have performed unit tests
- [x] I have added necessary docs
- [x] I have checked for potential bugs & issues