### PR TITLE
feature/password_reset : add account password reset method

### DIFF
--- a/myapp/src/config/email.js
+++ b/myapp/src/config/email.js
@@ -1,5 +1,6 @@
 /** load email config from env */
 const verificationMailTemplate = `<h1>Enter the Verification Code Below \n\n\n\n\n</h1>`;
+const passwordResetMailTemplate = `<h1>Here is the new password for your FORK account \n\n\n\n\n</h1>`;
 
 module.exports = {
     nodeMailConfig: {
@@ -13,4 +14,5 @@ module.exports = {
         },
     },
     mailTemplate: verificationMailTemplate,
+    passwordResetMailTemplate: passwordResetMailTemplate,
 };

--- a/myapp/src/controllers/authController.js
+++ b/myapp/src/controllers/authController.js
@@ -72,4 +72,20 @@ module.exports = {
             next(err);
         }
     },
+    /** request password reset
+     * - generate random password
+     * - send mail to account email containing the new password
+     * - update DB w/ new password
+     */
+    resetPassword: async (req, res, next) => {
+        try {
+            await authService.resetPassword(req.body.userId);
+            res.status(201).json({
+                status: 'success',
+                message: 'Password reset mail sent', // hide email
+            });
+        } catch (err) {
+            next(err);
+        }
+    },
 };

--- a/myapp/src/helper/helper.js
+++ b/myapp/src/helper/helper.js
@@ -38,6 +38,11 @@ module.exports = {
         const num = Math.floor(Math.random() * 1000000);
         return num.toString().padStart(6, '0');
     },
+    generateRandomPassword: (length) => {
+        return Math.random()
+            .toString(36)
+            .substring(2, 2 + length);
+    },
     /** request validation */
     validateUserId: (userId) => userNamePattern.test(userId),
     validatePassword: (password) => passwordPattern.test(password),

--- a/myapp/src/helper/mailSender.js
+++ b/myapp/src/helper/mailSender.js
@@ -1,7 +1,7 @@
 const nodemailer = require('nodemailer');
 
-const { nodeMailConfig, mailTemplate } = require('../config/email');
-const { generateRandomCode } = require('../helper/helper');
+const { nodeMailConfig, mailTemplate, passwordResetMailTemplate } = require('../config/email');
+const { generateRandomCode, generateRandomPassword } = require('../helper/helper');
 
 const transporter = nodemailer.createTransport(nodeMailConfig);
 
@@ -25,6 +25,28 @@ module.exports = {
             throw {
                 status: 500,
                 message: `Error occured while sending verification mail : ${err.message}`,
+            };
+        }
+    },
+    /** send password reset mail */
+    sendPasswordResetMail: async (dest) => {
+        const password = generateRandomPassword(10); // default length : 10
+        const mailOptions = {
+            from: process.env.NODEMAIL_ADDRESS,
+            to: dest,
+            subject: ' FORK - Password Reset ',
+            html: passwordResetMailTemplate + `<h3>\t${password}\t<h3>`,
+        };
+        try {
+            const info = await transporter.sendMail(mailOptions);
+            return {
+                info: info,
+                newPassword: password,
+            };
+        } catch (err) {
+            throw {
+                status: 500,
+                message: `Error occured while sending password-reset mail : ${err.message}`,
             };
         }
     },

--- a/myapp/src/routes/authRoutes.js
+++ b/myapp/src/routes/authRoutes.js
@@ -73,6 +73,16 @@ router
             validatorChecker,
         ],
         authController.signOutUser
+    )
+    .post(
+        // POST : request password reset
+        '/reset-password',
+        checkPermission([-1, 0]),
+        [
+            body('userId', `body field 'userId' should be string`).exists().isString(),
+            validatorChecker,
+        ],
+        authController.resetPassword
     );
 
 module.exports = router;


### PR DESCRIPTION
## What was added
- add new request for user password reset
    - `POST /api/auth/reset-password`
    - check user with `body.userId` (account id)
    - random password of length 10 -> sent to user email
    - update DB with generated password
    - retry -> simply re-request this

## Related Issues
- link related issues here
- [REPO_NAME #issueNum](issue_address)

## Future Works
- What else should be done ?

## Checklist
- [x] I have performed unit tests
- [x] I have added necessary docs
- [x] I have checked for potential bugs & issues