### PR TITLE
feat : add review summary by openAI API

### DIFF
--- a/myapp/package.json
+++ b/myapp/package.json
@@ -37,6 +37,7 @@
     "multer": "^1.4.5-lts.1",
     "multer-s3": "^3.0.1",
     "nodemailer": "^6.9.13",
+    "openai": "^4.47.3",
     "pg": "^8.11.5",
     "pg-hstore": "^2.3.4"
   }

--- a/myapp/src/controllers/reviewController.js
+++ b/myapp/src/controllers/reviewController.js
@@ -95,6 +95,18 @@ module.exports = {
             next(err);
         }
     },
+    /** get a summary by facility ID */
+    getSummaryByFacilityId: async (req, res, next) => {
+        try {
+            const result = await reviewService.getSummaryByFacilityId(req.params.facility);
+            res.status(200).json({
+                status: 'success',
+                data: result,
+            });
+        } catch (err) {
+            next(err);
+        }
+    },
     /** get all hashtags */
     getAllHashtags: async (req, res, next) => {
         try {

--- a/myapp/src/controllers/reviewController.js
+++ b/myapp/src/controllers/reviewController.js
@@ -98,7 +98,7 @@ module.exports = {
     /** get a summary by facility ID */
     getSummaryByFacilityId: async (req, res, next) => {
         try {
-            const result = await reviewService.getSummaryByFacilityId(req.params.facility);
+            const result = await reviewService.getSummaryByFacilityId(req.params.facility, req.query.force);
             res.status(200).json({
                 status: 'success',
                 data: result,

--- a/myapp/src/controllers/reviewController.js
+++ b/myapp/src/controllers/reviewController.js
@@ -98,7 +98,10 @@ module.exports = {
     /** get a summary by facility ID */
     getSummaryByFacilityId: async (req, res, next) => {
         try {
-            const result = await reviewService.getSummaryByFacilityId(req.params.facility, req.query.force);
+            const result = await reviewService.getSummaryByFacilityId(
+                req.params.facility,
+                req.query.force
+            );
             res.status(200).json({
                 status: 'success',
                 data: result,

--- a/myapp/src/helper/helper.js
+++ b/myapp/src/helper/helper.js
@@ -41,6 +41,10 @@ module.exports = {
             .toString(36)
             .substring(2, 2 + length);
     },
+    splitByDelimiter: (data, delim) => {
+        const pos = data ? data.indexOf(delim) : -1;
+        return pos > 0 ? [data.substr(0, pos), data.substr(pos + 1)] : ['', ''];
+    },
     /** request validation */
     validateUserId: (userId) => userNamePattern.test(userId),
     validatePassword: (password) => passwordPattern.test(password),

--- a/myapp/src/helper/openAi.js
+++ b/myapp/src/helper/openAi.js
@@ -1,0 +1,68 @@
+const { OpenAI } = require('openai');
+
+// GPT configs, prompt templates
+const modelName = 'gpt-3.5-turbo';
+const temperature = 0.6;
+const maxTokens = 60;
+const initialMessageTemplate = {
+    role: 'system',
+    content: `You are a skilled chef and a restaurant owner. \
+        You know how to summarize the customer reviews of your restaurant, and extract only the keywords. \
+        You are a multilingual, fluent in both English and Korean.`,
+};
+const summaryPromptTemplate = {
+    role: 'user',
+    content: `I will give you a list of customer reviews for your restaurant. \
+        The reviews are written in either English or Korean. \
+        Give me a summary of all the reviews. \
+        Translate the output text into English. \
+        Provide the output as bullet points. \
+        Each review is delimited by triple quotes. \
+        List of reviews : \
+        `,
+};
+
+class summaryModel {
+    constructor() {
+        this.client = new OpenAI({
+            apiKey: process.env.OPENAI_KEY,
+        });
+    }
+
+    /** chat completion with list of messages as input
+     * - each message is form of { role, content }
+     * - roles : 'system' -> for setup, 'user' -> for prompting
+     */
+    async chatCompletion(messages) {
+        const completion = await this.client.chat.completions.create({
+            model: modelName,
+            messages: messages,
+            temperature: temperature,
+            max_tokens: maxTokens,
+        });
+        return completion.choices[0].message;
+    }
+
+    /** make formatted prompt
+     * - (args) list of reviews
+     * - enclose each review in """
+     */
+    makePrompt(reviews) {
+        const formattedReviews = reviews.reduce((acc, curr) => {
+            return acc + `"""${curr}""" `;
+        });
+        return {
+            role: summaryPromptTemplate.role,
+            content: formattedReviews,
+        };
+    }
+
+    /** generate a summary of reviews */
+    async generateSummary(reviews) {
+        const prompt = this.makePrompt(reviews);
+        const chatResponse = await this.chatCompletion([initialMessageTemplate, prompt]);
+        return chatResponse.content;
+    }
+}
+
+module.exports = new summaryModel();

--- a/myapp/src/routes/reviewRoutes.js
+++ b/myapp/src/routes/reviewRoutes.js
@@ -94,9 +94,7 @@ router
             param('facility', `route param 'facility' must be a positive integer`)
                 .exists()
                 .isInt({ min: 1 }),
-            query('force', `optional query field 'force' must be boolean`)
-                .optional()
-                .isBoolean(),
+            query('force', `optional query field 'force' must be boolean`).optional().isBoolean(),
             validatorChecker,
         ],
         reviewController.getSummaryByFacilityId

--- a/myapp/src/routes/reviewRoutes.js
+++ b/myapp/src/routes/reviewRoutes.js
@@ -94,6 +94,9 @@ router
             param('facility', `route param 'facility' must be a positive integer`)
                 .exists()
                 .isInt({ min: 1 }),
+            query('force', `optional query field 'force' must be boolean`)
+                .optional()
+                .isBoolean(),
             validatorChecker,
         ],
         reviewController.getSummaryByFacilityId

--- a/myapp/src/routes/reviewRoutes.js
+++ b/myapp/src/routes/reviewRoutes.js
@@ -86,6 +86,17 @@ router
             validatorChecker,
         ],
         reviewController.deleteReview
+    )
+    .get(
+        // GET : get summary by facility ID
+        '/summary/:facility',
+        [
+            param('facility', `route param 'facility' must be a positive integer`)
+                .exists()
+                .isInt({ min: 1 }),
+            validatorChecker,
+        ],
+        reviewController.getSummaryByFacilityId
     );
 
 /** Router for "api/hashtags" */

--- a/myapp/src/services/reviewService.js
+++ b/myapp/src/services/reviewService.js
@@ -209,7 +209,7 @@ module.exports = {
                 });
 
                 // generate or use stored summary
-                if (storedSummary.rows.length && !parseBoolean(forceRecreate) ) {
+                if (storedSummary.rows.length && !parseBoolean(forceRecreate)) {
                     summary = storedSummary.rows[0].summary;
                 } else {
                     summary = await summaryModel.generateSummary(reviews.map((e) => e.content));

--- a/myapp/src/services/reviewService.js
+++ b/myapp/src/services/reviewService.js
@@ -67,7 +67,7 @@ module.exports = {
             // new code - make array of {id, name} from args.hashtags (array of names)
             const hashtagArray = [];
             for await (const h of args.hashtags) {
-                const { rows } = await db.query({
+                const { rows } = await client.query({
                     text: `select * from hashtag where name = $1 or (slug <> '' and slug = slugify($1))`,
                     values: [h],
                 });
@@ -128,7 +128,7 @@ module.exports = {
             // new code - make array of {id, name} from args.hashtags (array of names)
             const hashtagArray = [];
             for await (const h of body.hashtags) {
-                const { rows } = await db.query({
+                const { rows } = await client.query({
                     text: `select * from hashtag where name = $1 or (slug <> '' and slug = slugify($1))`,
                     values: [h],
                 });

--- a/myapp/src/services/reviewService.js
+++ b/myapp/src/services/reviewService.js
@@ -1,6 +1,7 @@
 const db = require('../models/index');
 const { parseBoolean } = require('../helper/helper');
 const { removeS3File } = require('../helper/s3Engine');
+const summaryModel = require('../helper/openAi');
 
 module.exports = {
     /** get review by review id */
@@ -186,6 +187,57 @@ module.exports = {
         }
         return result.rows;
     },
+
+    /** get a summary of a single facility
+     * - conditions for a summary to be generated
+     * - more than 3 reviews total
+     * - (1) there is a cached summary but updated_at : older than 24 hrs
+     * - (2) there is no cached summary
+     */
+    getSummaryByFacilityId: async (facilityId) => {
+        const client = await db.connect();
+        try {
+            let summary = '';
+            const reviews = await module.exports.getReviewByQuery({ facility: facilityId });
+
+            // criteria : more than 3 reviews
+            if (reviews.length >= 3) {
+                console.log(reviews.length);
+                // check for summary stored in DB - only if its made in the last 24 hrs
+                const storedSummary = await client.query({
+                    text: `select * from summary where facility_id = $1 and updated_at > now() - interval '24 hours' `,
+                    values: [facilityId],
+                });
+                console.log(storedSummary.rows);
+
+                // generate or use stored summary
+                if (storedSummary.rows.length) {
+                    summary = storedSummary.rows[0].summary;
+                } else {
+                    summary = await summaryModel.generateSummary(reviews.map((e) => e.content));
+                    console.log(summary);
+
+                    // store new summary in DB
+                    await client.query({
+                        text: `insert into summary (facility_id, summary) values ($1, $2)
+                            on conflict on constraint summary_pkey do update set summary = $2`,
+                        values: [facilityId, summary],
+                    });
+                }
+            }
+            await client.query('COMMIT');
+            return {
+                id: facilityId,
+                summary: summary,
+            };
+        } catch (err) {
+            await client.query('ROLLBACK');
+            throw err;
+        } finally {
+            client.release();
+        }
+    },
+
     /** get all hashtags */
     getAllHashtags: async () => {
         const query = {

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -1184,10 +1184,39 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/node-fetch@^2.6.4":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
+"@types/node@*":
+  version "20.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.0.tgz#49ceec7b34f8621470cff44677fa9d461a477f17"
+  integrity sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^18.11.18":
+  version "18.19.33"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.33.tgz#98cd286a1b8a5e11aa06623210240bcc28e95c48"
+  integrity sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==
+  dependencies:
+    undici-types "~5.26.4"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1213,6 +1242,13 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agentkeepalive@^4.2.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.5.0.tgz#2673ad1389b3c418c5a20c5d7364f93ca04be923"
+  integrity sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==
+  dependencies:
+    humanize-ms "^1.2.1"
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -1337,6 +1373,11 @@ arraybuffer.prototype.slice@^1.0.3:
     get-intrinsic "^1.2.3"
     is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 available-typed-arrays@^1.0.7:
   version "1.0.7"
@@ -1504,6 +1545,13 @@ color-support@^1.1.2:
   resolved "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
@@ -1638,6 +1686,11 @@ define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -1934,6 +1987,11 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 events@3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
@@ -2072,6 +2130,28 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data-encoder@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
+  integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+formdata-node@^4.3.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-4.4.1.tgz#23f6a5cb9cb55315912cbec4ff7b0f59bbd191e2"
+  integrity sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==
+  dependencies:
+    node-domexception "1.0.0"
+    web-streams-polyfill "4.0.0-beta.3"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2280,6 +2360,13 @@ https-proxy-agent@^5.0.0:
   dependencies:
     agent-base "6"
     debug "4"
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
+  dependencies:
+    ms "^2.0.0"
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -2652,7 +2739,7 @@ mime-db@1.52.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -2729,7 +2816,7 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2771,6 +2858,11 @@ node-addon-api@^5.0.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+
+node-domexception@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
 node-fetch@^2.6.7:
   version "2.7.0"
@@ -2900,6 +2992,20 @@ once@^1.3.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+openai@^4.47.3:
+  version "4.47.3"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.47.3.tgz#5d01f4a5a06fc390ba67477848278ffc9b3b2b2c"
+  integrity sha512-470d4ibH5kizXflCzgur22GpM4nOjrg7WQ9jTOa3dNKEn248oBy4+pjOyfcFR4V4YUn/YlDNjp6h83PbviCCKQ==
+  dependencies:
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
+    web-streams-polyfill "^3.2.1"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -3588,6 +3694,11 @@ underscore@^1.13.1:
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
@@ -3624,6 +3735,16 @@ vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+web-streams-polyfill@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
+  integrity sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==
+
+web-streams-polyfill@^3.2.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## What was added
- added dependency : openai
- new DB table `summary`
- add openAI client
    - API key pulled from ENV
    - added model configs, prompt templates, handler class
    - method for generating summary - list of keywords
- add method `GET /api/reviews/summary/:facility`
    - seperate from getReviewsByQuery?facility
    - use route param - facility id

### Logic for generating a new summary
    - more than 3 reviews exist currently for the facility
    - check db table `summary`
        (1) cached summary younger than 24hours exist -> use cached summary
        (2) else -> generate new summary by API call -> save into db

### estimated API calls
  - 1 per day, per facility

## Related Issues

## Future Works
- GPT output post-processing

## Checklist
- [x] I have performed unit tests
- [x] I have added necessary docs
- [x] I have checked for potential bugs & issues