### PR TITLE
fix : empty hashtag array in request createReview, updateReview

### DIFF
--- a/myapp/src/services/reviewService.js
+++ b/myapp/src/services/reviewService.js
@@ -116,7 +116,7 @@ module.exports = {
             const reviewId = result.rows[0]['id'];
 
             // insert hashtags only if nonempty
-            if (hashtagIds.length){
+            if (hashtagIds.length) {
                 const insertJunctionQuery = `insert into review_hashtag (review_id, hashtag_id)
                     values ${hashtagIds.map((e) => `(${reviewId}, ${e})`).join(`, `)}`;
                 await client.query(insertJunctionQuery);
@@ -179,9 +179,9 @@ module.exports = {
             });
 
             // insert hashtags only if nonempty
-            if (hashtagIds.length){
+            if (hashtagIds.length) {
                 const insertJunctionQuery = `insert into review_hashtag (review_id, hashtag_id)
-                    values ${hashtagIds.map((e) => `(${reviewId}, ${e})`).join(`, `)}`;
+                    values ${hashtagIds.map((e) => `(${id}, ${e})`).join(`, `)}`;
                 await client.query(insertJunctionQuery);
             }
 

--- a/myapp/src/services/reviewService.js
+++ b/myapp/src/services/reviewService.js
@@ -114,9 +114,14 @@ module.exports = {
                 ],
             });
             const reviewId = result.rows[0]['id'];
-            const insertJunctionQuery = `insert into review_hashtag (review_id, hashtag_id)
-                values ${hashtagIds.map((e) => `(${reviewId}, ${e})`).join(`, `)}`;
-            await client.query(insertJunctionQuery);
+
+            // insert hashtags only if nonempty
+            if (hashtagIds.length){
+                const insertJunctionQuery = `insert into review_hashtag (review_id, hashtag_id)
+                    values ${hashtagIds.map((e) => `(${reviewId}, ${e})`).join(`, `)}`;
+                await client.query(insertJunctionQuery);
+            }
+
             result = await client.query({
                 text: `select * from review_with_hashtag r where id = $1`,
                 values: [reviewId],
@@ -172,9 +177,14 @@ module.exports = {
                 text: `delete from review_hashtag where review_id = $1`,
                 values: [id],
             });
-            const insertJunctionQuery = `insert into review_hashtag (review_id, hashtag_id)
-                values ${hashtagIds.map((e) => `(${id}, ${e})`).join(`, `)}`;
-            await client.query(insertJunctionQuery);
+
+            // insert hashtags only if nonempty
+            if (hashtagIds.length){
+                const insertJunctionQuery = `insert into review_hashtag (review_id, hashtag_id)
+                    values ${hashtagIds.map((e) => `(${reviewId}, ${e})`).join(`, `)}`;
+                await client.query(insertJunctionQuery);
+            }
+
             result = await client.query({
                 text: `select * from review_with_hashtag r where id = $1`,
                 values: [id],


### PR DESCRIPTION
## What was added
- fixed an error where request field 'hashtags' array being `[]` returns SQL syntax error

## Related Issues
- link related issues here
- [REPO_NAME #issueNum](issue_address)

## Future Works
- What else should be done ?

## Checklist
- [x] I have performed unit tests
- [x] I have added necessary docs
- [x] I have checked for potential bugs & issues